### PR TITLE
Fail if any documents are skipped outside of context.skip.

### DIFF
--- a/lib/cob_az_index/indexer_config.rb
+++ b/lib/cob_az_index/indexer_config.rb
@@ -22,9 +22,7 @@ settings do
   provide "solr_writer.commit_timeout", (15 * 60)
   provide "solr.url", solr_url
   provide "solr_writer.commit_on_close", "false"
-
-  # set this to be non-negative if threshold should be enforced
-  provide "solr_writer.max_skipped", -1
+  provide "solr_writer.max_skipped", 0
 
   if ENV["SOLR_AUTH_USER"] && ENV["SOLR_AUTH_PASSWORD"]
     client = HTTPClient.new


### PR DESCRIPTION
This makes sure that airflow task is marked as error when ingest fails.