### PR TITLE
Configure basic auth via traject configuration.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -108,7 +108,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     rainbow (3.0.0)
     rake (10.5.0)
     rb-fsevent (0.10.3)
@@ -150,7 +150,7 @@ GEM
     thread_safe (0.3.6)
     tins (1.20.2)
     to_regexp (0.2.1)
-    traject (3.1.0)
+    traject (3.2.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
       hashie (~> 3.1)
@@ -179,7 +179,7 @@ PLATFORMS
 
 DEPENDENCIES
   binding_of_caller (~> 0.7)
-  bundler (~> 1.16)
+  bundler (>= 1.16)
   cob_az_index!
   coveralls
   guard (~> 2.14)
@@ -191,4 +191,4 @@ DEPENDENCIES
   rubocop (~> 0.52)
 
 BUNDLED WITH
-   1.16.6
+   2.0.2

--- a/cob_az_index.gemspec
+++ b/cob_az_index.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httparty"
   spec.add_runtime_dependency("gli", "~> 2.18")
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.52"

--- a/lib/cob_az_index/indexer_config.rb
+++ b/lib/cob_az_index/indexer_config.rb
@@ -27,9 +27,8 @@ settings do
   provide "solr_writer.max_skipped", -1
 
   if ENV["SOLR_AUTH_USER"] && ENV["SOLR_AUTH_PASSWORD"]
-    client = HTTPClient.new
-    client.set_auth(solr_url, ENV["SOLR_AUTH_USER"], ENV["SOLR_AUTH_PASSWORD"])
-    provide "solr_json_writer.http_client", client
+    provide "solr_json_writer.basic_auth_user", ENV["SOLR_AUTH_USER"]
+    provide "solr_json_writer.basic_auth_password", ENV["SOLR_AUTH_PASSWORD"]
   end
 end
 


### PR DESCRIPTION
Traject 3.2 now allows basic auth configuration.  We are updating
traject to the new version and taking advantage of this new feature.