### PR TITLE
Fix pull methods error on JSON.parse

### DIFF
--- a/exe/cob_az_index
+++ b/exe/cob_az_index
@@ -42,6 +42,15 @@ class App
     end
   end
 
+  desc "Pulls databases from Alma API and outputs to STDOUT as a JSON string"
+  command :pull do |c|
+
+    c.desc "Pulls databases from Alma API and outputs to STDOUT as a JSON string"
+    c.action do |global_options, options, args|
+      puts CobAzIndex::CLI.pull()
+    end
+  end
+
   pre do |global, command, options, args|
     # Pre logic here
     # Return true to proceed; false to abort and not call the

--- a/lib/cob_az_index.rb
+++ b/lib/cob_az_index.rb
@@ -22,7 +22,7 @@ module CobAzIndex
       endpoint = "https://lgapi-us.libapps.com/1.2/oauth/token"
 
       response = HTTParty.post(endpoint, body: { client_id: client_id, client_secret: client_secret, grant_type: "client_credentials" })
-      cred = JSON.parse(response)
+      cred = JSON.parse(response.body)
 
       endpoint = "https://lgapi-us.libapps.com/1.2/az"
       token = cred["access_token"]


### PR DESCRIPTION
* Also adds new convenience command `cob_az_index pull` to pull latest
databases as to local as a JSON string.